### PR TITLE
Update search.go

### DIFF
--- a/search.go
+++ b/search.go
@@ -105,7 +105,7 @@ func (conn SplunkConnection) SearchStream(searchString string, params ...map[str
 				events <- &row
 			}
 		}
-		events <- nil //Signal EOF
+		defer close(events) //Signal EOF
 	}()
 
 	return events,err


### PR DESCRIPTION
SearchStream: gracefully closing of the events channel
On line 108 there is a nil sent to the events channel which keeps the channel still open.
Changing it to a deferred close fixes the issue.